### PR TITLE
Typo: IPyhton -> IPython

### DIFF
--- a/examples/IPython Kernel/Beyond Plain Python.ipynb
+++ b/examples/IPython Kernel/Beyond Plain Python.ipynb
@@ -611,7 +611,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The IPyhton 'magic' functions are a set of commands, invoked by prepending one or two `%` signs to their name, that live in a namespace separate from your normal Python variables and provide a more command-like interface.  They take flags with `--` and arguments without quotes, parentheses or commas. The motivation behind this system is two-fold:\n",
+    "The IPython 'magic' functions are a set of commands, invoked by prepending one or two `%` signs to their name, that live in a namespace separate from your normal Python variables and provide a more command-like interface.  They take flags with `--` and arguments without quotes, parentheses or commas. The motivation behind this system is two-fold:\n",
     "    \n",
     "- To provide an orthogonal namespace for controlling IPython itself and exposing other system-oriented functionality.\n",
     "\n",


### PR DESCRIPTION
Just a quick one I noticed on another run through.