### PR TITLE
Correct notebook basics

### DIFF
--- a/examples/Notebook/Notebook Basics.ipynb
+++ b/examples/Notebook/Notebook Basics.ipynb
@@ -216,10 +216,10 @@
     "\n",
     "1. Basic navigation: `enter`, `shift-enter`, `up/k`, `down/j`\n",
     "2. Saving the notebook: `s`\n",
-    "2. Cell types: `y`, `m`, `1-6`, `t`\n",
-    "3. Cell creation: `a`, `b`\n",
-    "4. Cell editing: `x`, `c`, `v`, `d`, `z`, `ctrl+shift+-`\n",
-    "5. Kernel operations: `i`, `.`"
+    "3. Cell types: `y`, `m`, `1-6`, `t`\n",
+    "4. Cell creation: `a`, `b`\n",
+    "5. Cell editing: `x`, `c`, `v`, `d`, `z`, `ctrl+shift+-`\n",
+    "6. Kernel operations: `i`, `.`"
    ]
   }
  ],

--- a/examples/Notebook/Notebook Basics.ipynb
+++ b/examples/Notebook/Notebook Basics.ipynb
@@ -216,7 +216,7 @@
     "\n",
     "1. Basic navigation: `enter`, `shift-enter`, `up/k`, `down/j`\n",
     "2. Saving the notebook: `s`\n",
-    "3. Cell types: `y`, `m`, `1-6`, `t`\n",
+    "3. Cell types: `y`, `m`, `1-6`, `r`\n",
     "4. Cell creation: `a`, `b`\n",
     "5. Cell editing: `x`, `c`, `v`, `d`, `z`, `ctrl+shift+-`\n",
     "6. Kernel operations: `i`, `.`"


### PR DESCRIPTION
Hello! I have noticed some minor typos in the `"Notebook Basics.ipynb"` file. Under the "Keyboard Navigation" section -> recommended command learning sequence.

- ensure the bullet points are in order (1 to 6)
- replace command `"t"` (I believe this is a typo) to `"r"`

Please kindly review and thank you!!!