### PR TITLE
Fix typo

### DIFF
--- a/examples/Interactive Widgets/Widget Basics.ipynb
+++ b/examples/Interactive Widgets/Widget Basics.ipynb
@@ -29,7 +29,7 @@
     }
    },
    "source": [
-    "Widgets are elements that exists in both the front-end and the back-end.\n",
+    "Widgets are elements that exist in both the front-end and the back-end.\n",
     "\n",
     "![Kernel & front-end diagram](../images/FrontendKernel.png)"
    ]


### PR DESCRIPTION
Minor grammar slip up.

"..elements that exists in both the.." -> "..elements that exist in both the.."