### PR TITLE
Added minimal Dockerfile for running IPython-in-Depth lab under Binder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM andrewosh/binder-base
+
+MAINTAINER Michael Bright <dockerfiles@mjbright.net>
+
+USER root
+
+RUN pip install --upgrade pip
+
+USER main
+


### PR DESCRIPTION
This Dockerfile will allow building an image on mybinder.org allowing to run the IPython-in-depth tutorial online on mybinder.org.

This is not intended to be used in conferences where WiFi is often limited, but could be a useful way to share the tutorial with individuals.
