### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/examples/IPython Kernel/Third Party Rich Output.ipynb
+++ b/examples/IPython Kernel/Third Party Rich Output.ipynb
@@ -357,7 +357,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Vincent](https://vincent.readthedocs.org/en/latest/) is a visualization library that uses the [Vega](http://trifacta.github.io/vega/) visualization grammar to build [d3.js](http://d3js.org/) based visualizations in the Notebook and on http://nbviewer.ipython.org. `Visualization` objects in Vincetn have rich HTML and JavaSrcript representations."
+    "[Vincent](https://vincent.readthedocs.io/en/latest/) is a visualization library that uses the [Vega](http://trifacta.github.io/vega/) visualization grammar to build [d3.js](http://d3js.org/) based visualizations in the Notebook and on http://nbviewer.ipython.org. `Visualization` objects in Vincetn have rich HTML and JavaSrcript representations."
    ]
   },
   {

--- a/examples/Notebook/Notebook Basics.ipynb
+++ b/examples/Notebook/Notebook Basics.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This lesson assumes that the user has Jupyter [installed](http://jupyter.readthedocs.org/en/latest/install.html) and that the notebook server can be started by running:\n",
+    "This lesson assumes that the user has Jupyter [installed](https://jupyter.readthedocs.io/en/latest/install.html) and that the notebook server can be started by running:\n",
     "\n",
     "    jupyter notebook\n",
     "\n",
@@ -72,7 +72,7 @@
    "source": [
     "### Clusters Tab\n",
     "\n",
-    "The clusters tab provides a summary view of [IPython Parallel](http://ipyparallel.readthedocs.org/en/latest/) clusters. The IPython Parallel extension must be [installed](https://github.com/ipython/ipyparallel) in order to use this feature.\n",
+    "The clusters tab provides a summary view of [IPython Parallel](https://ipyparallel.readthedocs.io/en/latest/) clusters. The IPython Parallel extension must be [installed](https://github.com/ipython/ipyparallel) in order to use this feature.\n",
     "\n",
     "<img src=\"images/dashboard_clusters_tab_4_0.png\" />"
    ]


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.