### PR TITLE
Fixes broken rendering of notebook links when displayed on binder

### DIFF
--- a/binder/Index.ipynb
+++ b/binder/Index.ipynb
@@ -15,10 +15,10 @@
     "\n",
     "Outline of some basics:\n",
     "\n",
-    "* [Notebook Basics](../examples/Notebook/Notebook Basics.ipynb)\n",
-    "* [IPython - beyond plain python](../examples/IPython Kernel/Beyond Plain Python.ipynb)\n",
-    "* [Markdown Cells](../examples/Notebook/Working With Markdown Cells.ipynb)\n",
-    "* [Rich Display System](../examples/IPython Kernel/Rich Output.ipynb)\n",
+    "* [Notebook Basics](../examples/Notebook/Notebook%20Basics.ipynb)\n",
+    "* [IPython - beyond plain python](../examples/IPython%20Kernel/Beyond%20Plain%20Python.ipynb)\n",
+    "* [Markdown Cells](../examples/Notebook/Working%20With%20Markdown%20Cells.ipynb)\n",
+    "* [Rich Display System](../examples/IPython%20Kernel/Rich%20Output.ipynb)\n",
     "* [Custom Display logic](../examples/IPython%20Kernel/Custom%20Display%20Logic.ipynb)\n",
     "* [Running a Secure Public Notebook Server](../examples/Notebook/Running%20the%20Notebook%20Server.ipynb#Securing-the-notebook-server)\n",
     "* [How Jupyter works](../examples/Notebook/Multiple%20Languages%2C%20Frontends.ipynb) to run code in different languages."
@@ -67,7 +67,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When I view the `binder/Index.ipynb` notebook on mybinder.org the first few links to other notebooks look broken:

![jupyter_screenshot](https://user-images.githubusercontent.com/3604134/46006960-b21fb680-c0b0-11e8-84fe-afa565e6db92.png)

Seems to be a problem rendering the links with spaces, although this doesn't seem to happen when you run the notebooks local in Jupyter.

Can be corrected by using hex encoding of the spaces (in this PR). Relates to https://github.com/ipython/ipython-in-depth/issues/56.