### PR TITLE
remove spaces from link targets

### DIFF
--- a/Index.ipynb
+++ b/Index.ipynb
@@ -13,13 +13,13 @@
    "source": [
     "Class outline:\n",
     "\n",
-    "* A quick installation check of [ipython](http://ipython.org/install.html) and [jupyter notebook]((http://jupyter.readthedocs.io/en/latest/install.html)\n",
+    "* A quick installation check of [ipython](https://ipython.org/install.html) and [jupyter notebook](https://jupyter.readthedocs.io/en/latest/install.html)\n",
     "* An overview of the IPython project from [the official website](http://ipython.org), and [jupyter](https://jupyter.org)\n",
     "* Super basic intro to the notebook: typing code.\n",
-    "* [Notebook Basics](examples/Notebook/Notebook Basics.ipynb)\n",
-    "* [IPython - beyond plain python](examples/IPython Kernel/Beyond Plain Python.ipynb)\n",
-    "* [Markdown Cells](examples/Notebook/Working With Markdown Cells.ipynb)\n",
-    "* [Rich Display System](examples/IPython Kernel/Rich Output.ipynb)\n",
+    "* [Notebook Basics](examples/Notebook/Notebook%20Basics.ipynb)\n",
+    "* [IPython - beyond plain python](examples/IPython%20Kernel/Beyond%20Plain%20Python.ipynb)\n",
+    "* [Markdown Cells](examples/Notebook/Working%20With%20Markdown%20Cells.ipynb)\n",
+    "* [Rich Display System](examples/IPython%20Kernel/Rich%20Output.ipynb)\n",
     "* [Custom Display logic](examples/IPython%20Kernel/Custom%20Display%20Logic.ipynb)\n",
     "* [Customizing IPython - a condensed version](exercises/Customization/Condensed.ipynb)\n",
     "* [Running a Secure Public Notebook Server](examples/Notebook/Running%20the%20Notebook%20Server.ipynb#Securing-the-notebook-server)\n",
@@ -76,7 +76,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/examples/Builtin Extensions/Index.ipynb
+++ b/examples/Builtin Extensions/Index.ipynb
@@ -43,9 +43,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Cython Magics](Cython Magics.ipynb): magics for compiling and running Cython code in a cell\n",
-    "* [Octave Magic](Octave Magic.ipynb): magics for running Octave code in a cell\n",
-    "* [R Magics](R Magics.ipynb): magics for running R code in a cell"
+    "* [Cython Magics](Cython%20Magics.ipynb): magics for compiling and running Cython code in a cell\n",
+    "* [Octave Magic](Octave%20Magic.ipynb): magics for running Octave code in a cell\n",
+    "* [R Magics](R%20Magics.ipynb): magics for running R code in a cell"
    ]
   }
  ],

--- a/examples/IPython Kernel/Capturing Output.ipynb
+++ b/examples/IPython Kernel/Capturing Output.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "IPython has a [cell magic](Cell Magics.ipynb), `%%capture`, which captures the stdout/stderr of a cell. With this magic you can discard these streams or store them in a variable."
+    "IPython has a [cell magic](Cell%20Magics.ipynb), `%%capture`, which captures the stdout/stderr of a cell. With this magic you can discard these streams or store them in a variable."
    ]
   },
   {

--- a/examples/IPython Kernel/Custom Display Logic.ipynb
+++ b/examples/IPython Kernel/Custom Display Logic.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As described in the [Rich Output](Rich Output.ipynb) tutorial, the IPython display system can display rich representations of objects in the following formats:\n",
+    "As described in the [Rich Output](Rich%20Output.ipynb) tutorial, the IPython display system can display rich representations of objects in the following formats:\n",
     "\n",
     "* JavaScript\n",
     "* HTML\n",

--- a/examples/IPython Kernel/Index.ipynb
+++ b/examples/IPython Kernel/Index.ipynb
@@ -39,12 +39,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Cell Magics](Cell Magics.ipynb)\n",
-    "* [Script Magics](Script Magics.ipynb)\n",
-    "* [Rich Output](Rich Output.ipynb)\n",
-    "* [Custom Display Logic](Custom Display Logic.ipynb)\n",
-    "* [Plotting in the Notebook](Plotting in the Notebook.ipynb)\n",
-    "* [Capturing Output](Capturing Output.ipynb)"
+    "* [Cell Magics](Cell%20Magics.ipynb)\n",
+    "* [Script Magics](Script%20Magics.ipynb)\n",
+    "* [Rich Output](Rich%20Output.ipynb)\n",
+    "* [Custom Display Logic](Custom%20Display%20Logic.ipynb)\n",
+    "* [Plotting in the Notebook](Plotting%20in%20the%20Notebook.ipynb)\n",
+    "* [Capturing Output](Capturing%20Output.ipynb)"
    ]
   },
   {
@@ -58,11 +58,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Background Jobs](Background Jobs.ipynb)\n",
-    "* [Trapezoid Rule](Trapezoid Rule.ipynb)\n",
+    "* [Background Jobs](Background%20Jobs.ipynb)\n",
+    "* [Trapezoid Rule](Trapezoid%20Rule.ipynb)\n",
     "* [SymPy](SymPy.ipynb)\n",
-    "* [Raw Input in the Notebook](Raw Input in the Notebook.ipynb)\n",
-    "* [Importing Notebooks](Importing Notebooks.ipynb)"
+    "* [Raw Input in the Notebook](Raw%20Input%20in%20the%20Notebook.ipynb)\n",
+    "* [Importing Notebooks](Importing%20Notebooks.ipynb)"
    ]
   },
   {

--- a/examples/Index.ipynb
+++ b/examples/Index.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [IPython Kernel](IPython Kernel/Index.ipynb): IPython's core syntax and command line features available in all frontends\n",
+    "* [IPython Kernel](IPython%20Kernel/Index.ipynb): IPython's core syntax and command line features available in all frontends\n",
     "* [Embedding](Embedding/Index.ipynb): Embedding and reusing IPython's components into other applications\n"
    ]
   }

--- a/examples/Interactive Widgets/Custom Widget - Hello World.ipynb
+++ b/examples/Interactive Widgets/Custom Widget - Hello World.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Index](Index.ipynb) - [Back](Widget Styling.ipynb)"
+    "[Index](Index.ipynb) - [Back](Widget%20Styling.ipynb)"
    ]
   },
   {
@@ -765,7 +765,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Index](Index.ipynb) - [Back](Widget Styling.ipynb)"
+    "[Index](Index.ipynb) - [Back](Widget%20Styling.ipynb)"
    ]
   }
  ],

--- a/examples/Interactive Widgets/Index.ipynb
+++ b/examples/Interactive Widgets/Index.ipynb
@@ -39,12 +39,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- [Using Interact](Using Interact.ipynb)\n",
-    "- [Widget Basics](Widget Basics.ipynb)  \n",
-    "- [Widget Events](Widget Events.ipynb)  \n",
-    "- [Widget Placement](Widget Placement.ipynb)  \n",
-    "- [Widget Styling](Widget Styling.ipynb)    \n",
-    "- [Custom Widget](Custom Widget - Hello World.ipynb)"
+    "- [Using Interact](Using%20Interact.ipynb)\n",
+    "- [Widget Basics](Widget%20Basics.ipynb)  \n",
+    "- [Widget Events](Widget%20Events.ipynb)  \n",
+    "- [Widget Placement](Widget%20Placement.ipynb)  \n",
+    "- [Widget Styling](Widget%20Styling.ipynb)    \n",
+    "- [Custom Widget](Custom%20Widget%20-%20Hello%20World.ipynb)"
    ]
   },
   {
@@ -58,10 +58,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- [Variable Inspector](Variable Inspector.ipynb)  \n",
-    "- [Export As (nbconvert)](Export As (nbconvert%29.ipynb)  \n",
-    "- [Nonblocking Console](Nonblocking Console.ipynb)  \n",
-    "- [File Upload Widget](File Upload Widget.ipynb)"
+    "- [Variable Inspector](Variable%20Inspector.ipynb)  \n",
+    "- [Export As (nbconvert)](Export%20As%20(nbconvert%29.ipynb)  \n",
+    "- [Nonblocking Console](Nonblocking%20Console.ipynb)  \n",
+    "- [File Upload Widget](File%20Upload%20Widget.ipynb)"
    ]
   },
   {
@@ -75,12 +75,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Beat Frequencies](Beat Frequencies.ipynb)\n",
-    "* [Exploring Graphs](Exploring Graphs.ipynb)\n",
+    "* [Beat Frequencies](Beat%20Frequencies.ipynb)\n",
+    "* [Exploring Graphs](Exploring%20Graphs.ipynb)\n",
     "* [Factoring](Factoring.ipynb)\n",
-    "* [Image Browser](Image Browser.ipynb)\n",
-    "* [Image Processing](Image Processing.ipynb)\n",
-    "* [Lorenz Differential Equations](Lorenz Differential Equations.ipynb)"
+    "* [Image Browser](Image%20Browser.ipynb)\n",
+    "* [Image Processing](Image%20Processing.ipynb)\n",
+    "* [Lorenz Differential Equations](Lorenz%20Differential%20Equations.ipynb)"
    ]
   }
  ],

--- a/examples/Interactive Widgets/Widget Basics.ipynb
+++ b/examples/Interactive Widgets/Widget Basics.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Index](Index.ipynb) - [Next](Widget List.ipynb)"
+    "[Index](Index.ipynb) - [Next](Widget%20List.ipynb)"
    ]
   },
   {
@@ -417,7 +417,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Index](Index.ipynb) - [Next](Widget List.ipynb)"
+    "[Index](Index.ipynb) - [Next](Widget%20List.ipynb)"
    ]
   }
  ],

--- a/examples/Interactive Widgets/Widget Events.ipynb
+++ b/examples/Interactive Widgets/Widget Events.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Index](Index.ipynb) - [Back](Widget List.ipynb) - [Next](Widget Styling.ipynb)"
+    "[Index](Index.ipynb) - [Back](Widget%20List.ipynb) - [Next](Widget Styling.ipynb)"
    ]
   },
   {
@@ -349,7 +349,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Index](Index.ipynb) - [Back](Widget List.ipynb) - [Next](Widget Styling.ipynb)"
+    "[Index](Index.ipynb) - [Back](Widget%20List.ipynb) - [Next](Widget Styling.ipynb)"
    ]
   }
  ],

--- a/examples/Interactive Widgets/Widget List.ipynb
+++ b/examples/Interactive Widgets/Widget List.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Index](Index.ipynb) - [Back](Widget Basics.ipynb) - [Next](Widget Events.ipynb)"
+    "[Index](Index.ipynb) - [Back](Widget%20Basics.ipynb) - [Next](Widget Events.ipynb)"
    ]
   },
   {
@@ -593,7 +593,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Index](Index.ipynb) - [Back](Widget Basics.ipynb) - [Next](Widget Events.ipynb)"
+    "[Index](Index.ipynb) - [Back](Widget%20Basics.ipynb) - [Next](Widget Events.ipynb)"
    ]
   }
  ],

--- a/examples/Interactive Widgets/Widget Styling.ipynb
+++ b/examples/Interactive Widgets/Widget Styling.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Index](Index.ipynb) - [Back](Widget Events.ipynb) - [Next](Custom Widget - Hello World.ipynb)"
+    "[Index](Index.ipynb) - [Back](Widget%20Events.ipynb) - [Next](Custom Widget - Hello World.ipynb)"
    ]
   },
   {
@@ -551,7 +551,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Index](Index.ipynb) - [Back](Widget Events.ipynb) - [Next](Custom Widget - Hello World.ipynb)"
+    "[Index](Index.ipynb) - [Back](Widget%20Events.ipynb) - [Next](Custom Widget - Hello World.ipynb)"
    ]
   }
  ],

--- a/examples/Notebook/Index.ipynb
+++ b/examples/Notebook/Index.ipynb
@@ -39,16 +39,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [What is the IPython Notebook?](What is the IPython Notebook%3F.ipynb)\n",
-    "* [Running the Notebook Server](Running the Notebook Server.ipynb)\n",
-    "* [Notebook Basics](Notebook Basics.ipynb)\n",
-    "* [Running Code](Running Code.ipynb)\n",
-    "* [Working With Markdown Cells](Working With Markdown Cells.ipynb)\n",
-    "* [Custom Keyboard Shortcuts](Custom Keyboard Shortcuts.ipynb)\n",
-    "* [JavaScript Notebook Extensions](JavaScript Notebook Extensions.ipynb)\n",
-    "* [Notebook Security](Notebook Security.ipynb)\n",
-    "* [Converting Notebooks With nbconvert](Converting Notebooks With nbconvert.ipynb)\n",
-    "* [Using nbconvert as a Library](Using nbconvert as a Library.ipynb)"
+    "* [What is the IPython Notebook?](What%20is%20the%20IPython%20Notebook%3F.ipynb)\n",
+    "* [Running the Notebook Server](Running%20the%20Notebook%20Server.ipynb)\n",
+    "* [Notebook Basics](Notebook%20Basics.ipynb)\n",
+    "* [Running Code](Running%20Code.ipynb)\n",
+    "* [Working With Markdown Cells](Working%20With%20Markdown%20Cells.ipynb)\n",
+    "* [Custom Keyboard Shortcuts](Custom%20Keyboard%20Shortcuts.ipynb)\n",
+    "* [JavaScript Notebook Extensions](JavaScript%20Notebook%20Extensions.ipynb)\n",
+    "* [Notebook Security](Notebook%20Security.ipynb)\n",
+    "* [Converting Notebooks With nbconvert](Converting%20Notebooks%20With%20nbconvert.ipynb)\n",
+    "* [Using nbconvert as a Library](Using%20nbconvert%20as%20a%20Library.ipynb)"
    ]
   },
   {
@@ -62,9 +62,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Importing Notebooks](Importing Notebooks.ipynb)\n",
-    "* [Connecting with the Qt Console](Connecting with the Qt Console.ipynb)\n",
-    "* [Typesetting Equations](Typesetting Equations.ipynb)"
+    "* [Importing Notebooks](Importing%20Notebooks.ipynb)\n",
+    "* [Connecting with the Qt Console](Connecting%20with%20the%20Qt%20Console.ipynb)\n",
+    "* [Typesetting Equations](Typesetting%20Equations.ipynb)"
    ]
   }
  ],

--- a/examples/Notebook/Notebook Basics.ipynb
+++ b/examples/Notebook/Notebook Basics.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "    jupyter notebook\n",
     "\n",
-    "For more details on how to run the notebook server, see [Running the Notebook Server](Running the Notebook Server.ipynb)."
+    "For more details on how to run the notebook server, see [Running the Notebook Server](Running%20the%20Notebook%20Server.ipynb)."
    ]
   },
   {

--- a/examples/Parallel Computing/Index.ipynb
+++ b/examples/Parallel Computing/Index.ipynb
@@ -39,7 +39,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Data Publication API](Data Publication API.ipynb) "
+    "* [Data Publication API](Data%20Publication%20API.ipynb) "
    ]
   },
   {
@@ -53,13 +53,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Monitoring an MPI Simulation - 1](Monitoring an MPI Simulation - 1.ipynb)\n",
-    "* [Monitoring an MPI Simulation - 2](Monitoring an MPI Simulation - 2.ipynb)\n",
-    "* [Parallel Decorator and map](Parallel Decorator and map.ipynb)\n",
-    "* [Parallel Magics](Parallel Magics.ipynb)\n",
-    "* [Using Dill](Using Dill.ipynb)\n",
-    "* [Using MPI with IPython Parallel](Using MPI with IPython Parallel.ipynb)\n",
-    "* [Monte Carlo Options](Monte Carlo Options.ipynb)"
+    "* [Monitoring an MPI Simulation - 1](Monitoring%20an%20MPI%20Simulation%20-%201.ipynb)\n",
+    "* [Monitoring an MPI Simulation - 2](Monitoring%20an%20MPI%20Simulation%20-%202.ipynb)\n",
+    "* [Parallel Decorator and map](Parallel%20Decorator%20and%20map.ipynb)\n",
+    "* [Parallel Magics](Parallel%20Magics.ipynb)\n",
+    "* [Using Dill](Using%20Dill.ipynb)\n",
+    "* [Using MPI with IPython Parallel](Using%20MPI%20with%20IPython%20Parallel.ipynb)\n",
+    "* [Monte Carlo Options](Monte%20Carlo%20Options.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
it's not valid markdown, escape spaces with `%20`

see https://github.com/jupyter/notebook/issues/3858 and https://github.com/jupyterlab/jupyterlab/issues/5153